### PR TITLE
Add scan subnet functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,46 @@ iex> Hades.new_command()
 > **INFO**: Currently only standard single IPv4 specified targets are supported. In the future I'll add support for IPv4 ranges specified with a subnetmask.
 > This will enable the functionality to scan targets in a specified IP range.
 
+### Simple ping scan for a subnet
+The snippet below ping scans the network, and lists the target machine if it responds to ping.
+```elixir
+iex> Hades.new_command()
+...> |> Hades.add_argument(Hades.Arguments.ScanTechniques.arg_sP())
+...> |> Hades.add_target("192.168.120.42/24")
+...> |> Hades.scan()
+02:28:50.664 [info]  NMAP Output: "Starting Nmap 7.80 ( https://nmap.org ) at 2020-03-02 02:28 W. Central Africa Standard Time\r\n"
+
+02:29:09.001 [info]  NMAP Output: "Nmap scan report for 192.168.100.1\r\n"
+
+02:29:09.001 [info]  NMAP Output: "Host is up (0.00s latency).\r\nMAC Address: F8:75:88:9D:F9:B5 (Huawei Technologies)\r\n"
+
+02:29:09.001 [info]  NMAP Output: "Nmap scan report for 192.168.100.2\r\n"
+
+02:29:09.001 [info]  NMAP Output: "Host is up (0.047s latency).\r\nMAC Address: 78:31:C1:D0:87:8E (Apple)\r\n"
+
+02:29:24.300 [info]  NMAP Output: "Nmap scan report for 192.168.100.3\r\n"
+
+02:29:24.300 [info]  NMAP Output: "Host is up.\r\n"
+
+02:29:26.568 [info]  NMAP Output: "Nmap done: 256 IP addresses (3 hosts up) scanned in 36.03 seconds\r\n"
+
+02:29:26.584 [info]  Port exit: :exit_status: 0
+
+
+02:29:26.584 [info]  DOWN message from port: #Port<0.83>
+%{
+  hosts: [
+    %{hostname: "", ip: "192.168.100.1F8:75:88:9D:F9:B5", ports: []},
+    %{hostname: "", ip: "192.168.100.278:31:C1:D0:87:8E", ports: []},
+    %{hostname: "", ip: "192.168.100.3", ports: []}
+  ],
+  time: %{
+    elapsed: 36.03,
+    endstr: "Mon Mar 02 02:29:26 2020",
+    unix: 1583112566
+}
+```
+
 ### Using the script argument
 The execution of `nmap -sV -version-all -script vulners` in `Hades` looks like the following:
 ```elixir
@@ -192,6 +232,8 @@ iex> Hades.new_command()
   }
 }
 ```
+
+
 Here the [nmap-vulners](https://github.com/vulnersCom/nmap-vulners) NSE script is used to provide informations on vulnerabilities of well-known services that are running on the target host.
 
 ## General Informations

--- a/lib/hades.ex
+++ b/lib/hades.ex
@@ -65,21 +65,32 @@ defmodule Hades do
   end
 
   @doc """
-  This function adds the ability to add a specific `target_ip` to the nmap `command`.
+  This function adds the ability to add a specific `target_ip` to the nmap `command` or scan a subnet
+  of a given `target_ip`.
+
   Currently there are only standard formatted IPv4 adresses supported.
   Inputs with trailing subnmasks are not supported, but I'll work on this in the future.
 
-  Returns a `%Hades.Command{}` with the added `target_ip`.
+  Returns a `%Hades.Command{}` with the added `target_ip` in case of single target scan, otherwise 
+  will return a `%Hades.Command{}` with the added `target_ip` and subnet to be scanned.
 
   ## Example
       iex> Hades.new_command()
       ...> |> Hades.add_target("192.168.120.42")
       %Hades.Command{scan_types: [], target: "192.168.120.42"}
+
+    ## Example for subnet scan
+      iex> Hades.new_command()
+      ...> |> Hades.add_target("192.168.120.42/24")
+      %Hades.Command{scan_types: [], target: "192.168.120.42/24"}
   """
   def add_target(%Command{} = command, target_ip) do
+    target_ip_and_subnet = String.splitter(target_ip, ["/"]) |> Enum.take(2)
+    ip_address = Enum.at(target_ip_and_subnet, 0)
+    subnet = Enum.at(target_ip_and_subnet, 1)
     target_ip =
-      case Helpers.check_ip_address(target_ip) do
-        {:ok, ip} -> ip
+      case Helpers.check_ip_address(ip_address) do
+        {:ok, ip} -> if subnet == nil do ip else "#{ip}#{"/"}#{subnet}" end
         _ -> nil
       end
 

--- a/lib/nmap.ex
+++ b/lib/nmap.ex
@@ -42,9 +42,17 @@ defmodule Hades.NMAP do
     Process.flag(:trap_exit, true)
 
     path = Helpers.hades_path()
+  
+    target_vector = String.splitter("#{target}", ["/"]) |> Enum.take(2)
+    command = if (length(target_vector) == 2) do 
+      subnet = Enum.at(target_vector, 1)
+      "nmap #{option} -oX #{path} #{target} / #{subnet}"
+    else
+      "nmap #{option} -oX #{path} #{target}"
+    end
 
     port =
-      Port.open({:spawn, "nmap #{option} -oX #{path} #{target}"}, [
+      Port.open({:spawn, command}, [
         :binary,
         :exit_status
       ])


### PR DESCRIPTION
This feature contains the following changes:

1) Adds the capability to scan a given subnet
2) Updates README.md and added a section describing how to perform a subnet scan.

```elixir
iex> Hades.new_command()
...> |> Hades.add_argument(Hades.Arguments.ScanTechniques.arg_sP())
...> |> Hades.add_target("192.168.120.42/24")
...> |> Hades.scan()
02:28:50.664 [info]  NMAP Output: "Starting Nmap 7.80 ( https://nmap.org ) at 2020-03-02 02:28 W. Central Africa Standard Time\r\n"

02:29:09.001 [info]  NMAP Output: "Nmap scan report for 192.168.100.1\r\n"

02:29:09.001 [info]  NMAP Output: "Host is up (0.00s latency).\r\nMAC Address: F8:75:88:9D:F9:B5 (Huawei Technologies)\r\n"

02:29:09.001 [info]  NMAP Output: "Nmap scan report for 192.168.100.2\r\n"

02:29:09.001 [info]  NMAP Output: "Host is up (0.047s latency).\r\nMAC Address: 78:31:C1:D0:87:8E (Apple)\r\n"

02:29:24.300 [info]  NMAP Output: "Nmap scan report for 192.168.100.3\r\n"

02:29:24.300 [info]  NMAP Output: "Host is up.\r\n"

02:29:26.568 [info]  NMAP Output: "Nmap done: 256 IP addresses (3 hosts up) scanned in 36.03 seconds\r\n"

02:29:26.584 [info]  Port exit: :exit_status: 0


02:29:26.584 [info]  DOWN message from port: #Port<0.83>
%{
  hosts: [
    %{hostname: "", ip: "192.168.100.1F8:75:88:9D:F9:B5", ports: []},
    %{hostname: "", ip: "192.168.100.278:31:C1:D0:87:8E", ports: []},
    %{hostname: "", ip: "192.168.100.3", ports: []}
  ],
  time: %{
    elapsed: 36.03,
    endstr: "Mon Mar 02 02:29:26 2020",
    unix: 1583112566
}
```
